### PR TITLE
Fix wrong indentation of merger.write()

### DIFF
--- a/pdf/pdfMerger.py
+++ b/pdf/pdfMerger.py
@@ -6,4 +6,4 @@ merger = PyPDF2.PdfFileMerger()
 for file in os.listdir(os.curdir):
     if file.endswith(".pdf"):
         merger.append(file)
-    merger.write("combined.pdf")
+merger.write("combined.pdf")


### PR DESCRIPTION
Fixed indentation of merger.write() which caused writing PDF files in a loop a multiple times.